### PR TITLE
Update README.md to clarify the name of config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ See [here](https://hugo-coder.netlify.app/).
 1. Add the repository into your Hugo Project repository as a submodule, `git submodule add https://github.com/luizdepra/hugo-coder.git themes/hugo-coder`.
 2. Configure your `config.toml`. You can either use [this minimal configuration](https://github.com/luizdepra/hugo-coder/blob/main/docs/configurations.md#complete-example) as a base, or look for a complete explanation about all configurations [here](https://github.com/luizdepra/hugo-coder/blob/main/docs/configurations.md). The [`config.toml`](https://github.com/luizdepra/hugo-coder/blob/master/exampleSite/config.toml) inside the [`exampleSite`](https://github.com/luizdepra/hugo-coder/tree/master/exampleSite) is also a good reference.
 3. Build your site with `hugo server` and see the result at `http://localhost:1313/`.
+Note: config.toml file can also be named as hugo.toml.
 
 ## Documentation
 


### PR DESCRIPTION
config.toml is now called hugo.toml

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.
- [x] Readme update

### Description

Hugo projects are now calling hugo.toml instead of config.toml to hugo config file. It's confusing for new user that where to put the configurations.

### Issues Resolved

- Simple document update.

### Checklist

Put an `x` into the box(es) that apply:

#### General

- [ ] Describe what changes are being made
- [ ] Explain why and how the changes were necessary and implemented respectively
- [ ] Reference issue with `#<ISSUE_NO>` if applicable

#### Resources

- [ ] If you have changed any SCSS code, run `make release` to regenerate all CSS files

#### Contributors

- [ ] Add yourself to `CONTRIBUTORS.md` if you aren't on it already
